### PR TITLE
Add GUID value to Solution file `.slnx`

### DIFF
--- a/OP2Editor.slnx
+++ b/OP2Editor.slnx
@@ -2,5 +2,5 @@
   <Configurations>
     <Platform Name="x86" />
   </Configurations>
-  <Project Path="OP2Editor.vcxproj" />
+  <Project Path="OP2Editor.vcxproj" Id="e7666a17-77d3-4dca-a706-a018977ceb3e" />
 </Solution>


### PR DESCRIPTION
For some reason Visual Studio didn't add the GUID value when first creating the `.slnx` file, though did prompt continually to save the changed file later on.

Related:
- PR #6
